### PR TITLE
Add gitsync bash script

### DIFF
--- a/gitsync
+++ b/gitsync
@@ -1,0 +1,12 @@
+#!/bin/bash
+# stop if not on master branch of local git repo
+git branch | awk '$1~/\*/{if($2~/master/){exit 0}else{exit 1}}'
+if [ $? -ne 0 ]; then
+    echo "STOP: not on master branch of local git repo"
+    exit 1
+fi
+# synchronize local git repo with central GitHub repo
+git fetch upstream
+git merge upstream/master
+git push origin master
+exit 0


### PR DESCRIPTION
This pull request adds a *nix bash shell script (for Unix, Linux, and MacOS) that makes it easy to synchronize the local, origin, and upstream repositories.  Need to add a Windows equivalent batch file (named `gitsync.bat`), but doing this may be somewhat complicated if `awk` is not available on a standard Windows installation.