### PR TITLE
Use full URLs to link documentation in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ If you want to **propose code changes**, follow the directions in the
 Guide](http://taxcalc.readthedocs.io/en/latest/contributor_guide.html)
 on how to clone the pitaxcalc-demo git repository.  Before developing
 any code changes be sure to read completely the Contributor Guide and
-then read about our [coding style](CODING.md#coding-style) and
-[testing procedures](TESTING.md#testing-procedures).  You may find
-this [git cheat sheet](SIMPLE_GIT_USAGE.md#simple-git-usage) useful in
-preparing a GitHub pull request that contains your proposed code
-changes.
+then read about our [coding
+style](https://github.com/TPRU-demo/pitaxcalc-demo/blob/master/CODING.md#coding-style)
+and [testing
+procedures](https://github.com/TPRU-demo/pitaxcalc-demo/blob/master/TESTING.md#testing-procedures).
+You may find this [git cheat
+sheet](https://github.com/TPRU-demo/pitaxcalc-demo/blob/master/SIMPLE_GIT_USAGE.md#simple-git-usage)
+useful in preparing a GitHub pull request that contains your proposed
+code changes.
 
 The pitaxcalc-demo [release history](RELEASES.md) provides a summary
 of past development work.


### PR DESCRIPTION
Minor cosmetic change to the repo documentation.