### PR TITLE
Add README.md link to the USA WORKFLOW.md documentation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ procedures](https://github.com/TPRU-demo/pitaxcalc-demo/blob/master/TESTING.md#t
 You may find this [git cheat
 sheet](https://github.com/TPRU-demo/pitaxcalc-demo/blob/master/SIMPLE_GIT_USAGE.md#simple-git-usage)
 useful in preparing a GitHub pull request that contains your proposed
-code changes.
+code changes.  The step-by-step workflow used to create and modify a
+new pull request has been documented for the USA Tax-Calculator in this
+[workflow document](https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow).
 
 The pitaxcalc-demo [release
 history](https://github.com/TPRU-demo/pitaxcalc-demo/blob/master/RELEASES.md#pitaxcalc-demo-release-history)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Build Status](https://travis-ci.org/TPRU-demo/pitaxcalc-demo.svg?branch=master)](https://travis-ci.org/TPRU-demo/pitaxcalc-demo)
+[![Codecov](https://codecov.io/gh/TPRU-demo/pitaxcalc-demo/branch/master/graph/badge.svg)](https://codecov.io/gh/TPRU-demo/pitaxcalc-demo)
+
+
 Demonstration repository for Personal Income Tax (PIT) microsimulation model
 ============================================================================
 


### PR DESCRIPTION
This PR adds a link to the step-by-step git workflow document for the USA Tax-Calculator project.
No change in tax logic; just adds more documentation.