### PR TITLE
Add a test of the consistency of calculated results

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -126,15 +126,14 @@ class Calculator(object):
             self.increment_year()
         assert self.current_year == year
 
-    def calc_all(self, zero_out_calc_vars=False):
+    def calc_all(self):
         """
         Call all tax-calculation functions for the current_year.
         """
         # pylint: disable=too-many-function-args,no-value-for-parameter
         # conducts static analysis of Calculator object for current_year
         assert self.__records.current_year == self.__policy.current_year
-        if zero_out_calc_vars:
-            self.__records.zero_out_changing_calculated_vars()
+        self.__records.zero_out_changing_calculated_vars()
         # pdb.set_trace()
         net_salary_income(self.__policy, self.__records)
         net_rental_income(self.__policy, self.__records)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -139,6 +139,9 @@ def pit_liability(calc):
     taxinc = np.maximum(0., agginc)
     calc.array('Aggregate_Income', taxinc)
     # calculate tax on taxable income subject to taxation at normal rates
+    # NOTE: Tax_ST_CG_APPRATE is not calculated here because its stacking
+    #       and scope assumptions have not been specified.  If it is ever
+    #       calculated here, be sure to add it to Total_Tax_STCG variable.
     AGEGRP = calc.array('AGEGRP')
     rate1 = calc.policy_param('rate1')
     rate2 = calc.policy_param('rate2')
@@ -181,3 +184,6 @@ def pit_liability(calc):
     calc.array('cess', cess)
     tax = tax + cess
     calc.array('pitax', tax)
+    # calculate Total_Tax_Cap_Gains
+    calc.array('Total_Tax_Cap_Gains',
+               calc.array('Total_Tax_STCG') + calc.array('Total_Tax_LTCG'))

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -94,13 +94,13 @@ def tax_stcg_splrate(calc):
     calc.array('Tax_ST_CG_RATE2', Tax_ST_CG_RATE2)
     calc.array('Total_Tax_STCG', Total_Tax_STCG)
     # update TI_special_rates
-    TI_special_rates = calc.array('TI_special_rates')
-    TI_special_rates += ST_CG_AMT_1 + ST_CG_AMT_2
-    calc.array('TI_special_rates', TI_special_rates)
+    old = calc.array('TI_special_rates')
+    new = old + ST_CG_AMT_1 + ST_CG_AMT_2
+    calc.array('TI_special_rates', new)
     # update tax_TI_special_rates
-    tax_TI_special_rates = calc.array('tax_TI_special_rates')
-    tax_TI_special_rates += Total_Tax_STCG
-    calc.array('tax_TI_special_rates', tax_TI_special_rates)
+    old = calc.array('tax_TI_special_rates')
+    new = old + Total_Tax_STCG
+    calc.array('tax_TI_special_rates', new)
 
 
 def tax_ltcg_splrate(calc):
@@ -118,13 +118,17 @@ def tax_ltcg_splrate(calc):
     calc.array('Tax_LT_CG_RATE2', Tax_LT_CG_RATE2)
     calc.array('Total_Tax_LTCG', Total_Tax_LTCG)
     # update TI_special_rates
-    TI_special_rates = calc.array('TI_special_rates')
-    TI_special_rates += LT_CG_AMT_1 + LT_CG_AMT_2
-    calc.array('TI_special_rates', TI_special_rates)
+    old = calc.array('TI_special_rates')
+    new = old + LT_CG_AMT_1 + LT_CG_AMT_2
+    calc.array('TI_special_rates', new)
     # update tax_TI_special_rates
-    tax_TI_special_rates = calc.array('tax_TI_special_rates')
-    tax_TI_special_rates += Total_Tax_LTCG
-    calc.array('tax_TI_special_rates', tax_TI_special_rates)
+    old = calc.array('tax_TI_special_rates')
+    new = old + Total_Tax_LTCG
+    calc.array('tax_TI_special_rates', new)
+
+
+DEBUG = False
+DEBUG_IDX = 0
 
 
 def pit_liability(calc):
@@ -137,6 +141,10 @@ def pit_liability(calc):
     # the portion of TTI that is taxed at normal rates
     agginc = calc.array('TTI') - calc.array('TI_special_rates')
     taxinc = np.maximum(0., agginc)
+    if DEBUG:
+        print('D:debug_output_for_idx=', DEBUG_IDX)
+        print('D:raw_Aggregate_Income=', agginc[DEBUG_IDX])
+        print('D:Aggregate_Income=', taxinc[DEBUG_IDX])
     calc.array('Aggregate_Income', taxinc)
     # calculate tax on taxable income subject to taxation at normal rates
     # NOTE: Tax_ST_CG_APPRATE is not calculated here because its stacking
@@ -160,29 +168,56 @@ def pit_liability(calc):
     surcharge_thd1 = calc.policy_param('surcharge_thd')[0]
     surcharge_thd2 = calc.policy_param('surcharge_thd')[1]
     cess_rate = calc.policy_param('cess_rate')
-    rebate = np.where(taxinc > rebate_thd, 0.,
-                      np.minimum(rebate_rate * taxinc, rebate_ceiling))
-    calc.array('rebate', rebate)
+    # compute tax on income taxed at normal rates
     tax_normal_rates = (rate1 * np.minimum(taxinc, tbrk1) +
                         rate2 * np.minimum(tbrk2 - tbrk1,
                                            np.maximum(0., taxinc - tbrk1)) +
                         rate3 * np.minimum(tbrk3 - tbrk2,
                                            np.maximum(0., taxinc - tbrk2)) +
                         rate4 * np.maximum(0., taxinc - tbrk3))
-    tax_TI_special_rates = calc.array('tax_TI_special_rates')
-    tax = tax_normal_rates + tax_TI_special_rates
-    calc.array('tax_TTI', tax)
-    tax = np.where(rebate > tax, 0, tax - rebate)
+    if DEBUG:
+        print('D:tax_Aggregate_Income=', tax_normal_rates[DEBUG_IDX])
+    calc.array('tax_Aggregate_Income', tax_normal_rates)
+    # compute tax_TTI
+    tax_TTI = tax_normal_rates + calc.array('tax_TI_special_rates')
+    if DEBUG:
+        print('D:tax_normal_rates+tax_TI_special_rates=', tax_TTI[DEBUG_IDX])
+    # NOTE: rebate_agri is defined in records_variables.json, but is never
+    #       calculated in functions.py, so its value is zero.
+    rebate_agri = np.minimum(tax_TTI,
+                             calc.array('rebate_agri'))  # is non-refundable
+    calc.array('rebate_agri', rebate_agri)  # capped rebate_agri amount
+    tax_TTI -= rebate_agri
+    if DEBUG:
+        print('D:tax_TTI=', tax_TTI[DEBUG_IDX])
+    calc.array('tax_TTI', tax_TTI)
+    # compute capped rebate amount
+    rebate = np.where(taxinc > rebate_thd, 0.,
+                      np.minimum(rebate_rate * taxinc, rebate_ceiling))
+    rebate = np.minimum(tax_TTI, rebate)  # rebate is a non-refundable credit
+    if DEBUG:
+        print('D:capped_rebate=', rebate[DEBUG_IDX])
+    calc.array('rebate', rebate)  # capped rebate amount
+    tax = tax_TTI - rebate
+    # compute surcharge amount
     surcharge = np.where(taxinc < surcharge_thd1, taxinc * surcharge_rate1,
                          np.where((taxinc >= surcharge_thd1) &
                                   (taxinc < surcharge_thd2),
                                   taxinc * surcharge_rate2,
                                   taxinc * surcharge_rate3))
+    if DEBUG:
+        print('D:surcharge=', surcharge[DEBUG_IDX])
     calc.array('surcharge', surcharge)
-    tax = tax + surcharge
+    tax += surcharge
+    # compute cess amount
     cess = tax * cess_rate
+    if DEBUG:
+        print('D:cess=', cess[DEBUG_IDX])
     calc.array('cess', cess)
-    tax = tax + cess
+    # compute pitax amount
+    tax += cess
+    if DEBUG:
+        print('D:pitax=', tax[DEBUG_IDX])
     calc.array('pitax', tax)
     # calculate Total_Tax_Cap_Gains
     calc.array('Total_Tax_Cap_Gains',

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -70,3 +70,16 @@ def test_Calculator_results_consistency(pit_fullsample):
                        vdf['GTI'] - vdf['deductions'])
     assert np.allclose(vdf['Aggregate_Income'],
                        vdf['TTI'] - vdf['TI_special_rates'])
+    assert np.all(vdf['Tax_ST_CG_RATE1'] >= 0.)
+    assert np.all(vdf['Tax_ST_CG_RATE2'] >= 0.)
+    assert np.all(vdf['Tax_ST_CG_APPRATE'] >= 0.)
+    assert np.allclose(vdf['Total_Tax_STCG'],
+                       (vdf['Tax_ST_CG_RATE1'] +
+                        vdf['Tax_ST_CG_RATE2'] +
+                        vdf['Tax_ST_CG_APPRATE']))
+    assert np.all(vdf['Tax_LT_CG_RATE1'] >= 0.)
+    assert np.all(vdf['Tax_LT_CG_RATE2'] >= 0.)
+    assert np.allclose(vdf['Total_Tax_LTCG'],
+                       vdf['Tax_LT_CG_RATE1'] + vdf['Tax_LT_CG_RATE2'])
+    assert np.allclose(vdf['Total_Tax_Cap_Gains'],
+                       vdf['Total_Tax_STCG'] + vdf['Total_Tax_LTCG'])

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -72,7 +72,7 @@ def test_Calculator_results_consistency(pit_fullsample):
                        vdf['TTI'] - vdf['TI_special_rates'])
     assert np.all(vdf['Tax_ST_CG_RATE1'] >= 0.)
     assert np.all(vdf['Tax_ST_CG_RATE2'] >= 0.)
-    assert np.all(vdf['Tax_ST_CG_APPRATE'] >= 0.)
+    assert np.all(vdf['Tax_ST_CG_APPRATE'] == 0.)
     assert np.allclose(vdf['Total_Tax_STCG'],
                        (vdf['Tax_ST_CG_RATE1'] +
                         vdf['Tax_ST_CG_RATE2'] +
@@ -83,3 +83,16 @@ def test_Calculator_results_consistency(pit_fullsample):
                        vdf['Tax_LT_CG_RATE1'] + vdf['Tax_LT_CG_RATE2'])
     assert np.allclose(vdf['Total_Tax_Cap_Gains'],
                        vdf['Total_Tax_STCG'] + vdf['Total_Tax_LTCG'])
+
+    assert np.all(vdf['tax_Aggregate_Income'] >= 0.)
+    assert np.all(vdf['tax_TI_special_rates'] >= 0.)
+    assert np.all(vdf['rebate_agri'] == 0.)
+    exp = vdf['tax_Aggregate_Income'] + vdf['tax_TI_special_rates']
+    exp -= vdf['rebate_agri']
+    assert np.allclose(vdf['tax_TTI'], exp)
+    assert np.all(vdf['rebate'] >= 0.)
+    assert np.all(vdf['surcharge'] >= 0.)
+    assert np.all(vdf['cess'] >= 0.)
+    assert np.all(vdf['pitax'] >= 0.)
+    exp = vdf['tax_TTI'] - vdf['rebate'] + vdf['surcharge'] + vdf['cess']
+    assert np.allclose(vdf['pitax'], exp)

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -52,7 +52,7 @@ def test_correct_Calculator_instantiation(pit_fullsample, pit_subsample):
     assert np.allclose([actual_sub_pitax], [expect_pitax], rtol=0.07)
     """
 
-@pytest.mark.one
+
 def test_Calculator_results_consistency(pit_fullsample):
     # generate calculated-variable dataframe for full sample in second year
     recs = Records(data=pit_fullsample)

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -83,7 +83,6 @@ def test_Calculator_results_consistency(pit_fullsample):
                        vdf['Tax_LT_CG_RATE1'] + vdf['Tax_LT_CG_RATE2'])
     assert np.allclose(vdf['Total_Tax_Cap_Gains'],
                        vdf['Total_Tax_STCG'] + vdf['Total_Tax_LTCG'])
-
     assert np.all(vdf['tax_Aggregate_Income'] >= 0.)
     assert np.all(vdf['tax_TI_special_rates'] >= 0.)
     assert np.all(vdf['rebate_agri'] == 0.)

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -51,3 +51,22 @@ def test_correct_Calculator_instantiation(pit_fullsample, pit_subsample):
     assert np.allclose([actual_sub_weight], [expect_weight])
     assert np.allclose([actual_sub_pitax], [expect_pitax], rtol=0.07)
     """
+
+@pytest.mark.one
+def test_Calculator_results_consistency(pit_fullsample):
+    # generate calculated-variable dataframe for full sample in second year
+    recs = Records(data=pit_fullsample)
+    calc = Calculator(policy=Policy(), records=recs)
+    assert isinstance(calc, Calculator)
+    assert calc.current_year == Policy.JSON_START_YEAR
+    calc.advance_to_year(Policy.JSON_START_YEAR + 1)
+    assert calc.current_year == Policy.JSON_START_YEAR + 1
+    calc.calc_all()
+    varlist = list(Records.CALCULATED_VARS)
+    vdf = calc.dataframe(varlist)
+    assert isinstance(vdf, pd.DataFrame)
+    # check consistency of calculated results individual by individual
+    assert np.allclose(vdf['TTI'],
+                       vdf['GTI'] - vdf['deductions'])
+    assert np.allclose(vdf['Aggregate_Income'],
+                       vdf['TTI'] - vdf['TI_special_rates'])


### PR DESCRIPTION
This pull request adds a consistency test that ensures the relationships between the calculated variables are as defined in the `records_variables.json` definitions of the calculated variables.  This new test is in the `taxcalc/tests/test_calculator.py` file and is called `test_Calculator_results_consistency`.

The addition of this test has highlighted the need for a number of changes to the `functions.py` code:
1. The `TI_special_rates` variable was not being calculated.
2. The `GTI` variable did not include the `TI_special_rates` amount.
3. The `Aggregate_Income` variable was not being calculated.
4. Skip `Tax_ST_CG_APPRATE` calculation because stacking and scope assumptions not specified.
5. The `Total_Tax_Cap_Gains` variable was not being calculated.

Notice that all the changes in this pull request leave the aggregate `pitax` revenue in `test_correct_Calculator_instantiation` unchanged, which shows that these changes have been made only to achieve consistency in the components of `pitax`, not to to change the calculated `pitax` amounts.  It was essential to achieve an all-inclusive `GTI` variable and consistent `pitax` components before beginning to develop distribution-tables logic.
