### PR TITLE
Add distribution tables for India PIT law

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -21,9 +21,7 @@ from taxcalc.functions import (net_salary_income, net_rental_income,
                                pit_liability)
 from taxcalc.policy import Policy
 from taxcalc.records import Records
-from taxcalc.utils import (DIST_VARIABLES, create_distribution_table,
-                           DIFF_VARIABLES, create_difference_table,
-                           create_diagnostic_table)
+from taxcalc.utils import DIST_VARIABLES, create_distribution_table
 # import pdb
 
 
@@ -176,17 +174,7 @@ class Calculator(object):
         Return pandas DataFrame containing the DIST_TABLE_COLUMNS variables
         from embedded Records object.
         """
-        pdf = self.dataframe(DIST_VARIABLES)
-        # weighted count of itemized-deduction returns
-        pdf['num_returns_ItemDed'] = pdf['weight'].where(
-            pdf['c04470'] > 0., 0.)
-        # weighted count of standard-deduction returns
-        pdf['num_returns_StandardDed'] = pdf['weight'].where(
-            pdf['standard'] > 0., 0.)
-        # weight count of returns with positive Alternative Minimum Tax (AMT)
-        pdf['num_returns_AMT'] = pdf['weight'].where(
-            pdf['c09600'] > 0., 0.)
-        return pdf
+        return self.dataframe(DIST_VARIABLES)
 
     def array(self, variable_name, variable_value=None):
         """
@@ -346,13 +334,13 @@ class Calculator(object):
 
     def distribution_tables(self, calc, groupby):
         """
-        Get results from self and calc, sort them by expanded_income into
-        table rows defined by groupby, compute grouped statistics, and
+        Get results from self and calc, sort them by GTI into table
+        rows defined by groupby, compute grouped statistics, and
         return tables as a pair of Pandas dataframes.
         This method leaves the Calculator object(s) unchanged.
         Note that the returned tables have consistent income groups (based
-        on the self expanded_income) even though the baseline expanded_income
-        in self and the reform expanded_income in calc are different.
+        on the self GTI) even though the baseline GTI in self and
+        the reform GTI in calc are different.
 
         Parameters
         ----------
@@ -387,12 +375,12 @@ class Calculator(object):
         # nested function used only by this method
         def have_same_income_measure(calc1, calc2):
             """
-            Return true if calc1 and calc2 contain the same expanded_income;
+            Return true if calc1 and calc2 contain the same GTI;
             otherwise, return false.  (Note that "same" means nobody's
-            expanded_income differs by more than one cent.)
+            GTI differs by more than one cent.)
             """
-            im1 = calc1.array('expanded_income')
-            im2 = calc2.array('expanded_income')
+            im1 = calc1.array('GTI')
+            im2 = calc2.array('GTI')
             return np.allclose(im1, im2, rtol=0.0, atol=0.01)
         # main logic of method
         assert calc is None or isinstance(calc, Calculator)
@@ -402,7 +390,7 @@ class Calculator(object):
             assert np.allclose(self.array('weight'),
                                calc.array('weight'))  # rows in same order
         var_dataframe = self.distribution_table_dataframe()
-        imeasure = 'expanded_income'
+        imeasure = 'GTI'
         dt1 = create_distribution_table(var_dataframe, groupby, imeasure)
         del var_dataframe
         if calc is None:
@@ -412,10 +400,10 @@ class Calculator(object):
             assert calc.array_len == self.array_len
             var_dataframe = calc.distribution_table_dataframe()
             if have_same_income_measure(self, calc):
-                imeasure = 'expanded_income'
+                imeasure = 'GTI'
             else:
-                imeasure = 'expanded_income_baseline'
-                var_dataframe[imeasure] = self.array('expanded_income')
+                imeasure = 'GTI_baseline'
+                var_dataframe[imeasure] = self.array('GTI')
             dt2 = create_distribution_table(var_dataframe, groupby, imeasure)
             del var_dataframe
         return (dt1, dt2)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -14,9 +14,7 @@ import pytest
 from taxcalc import Policy, Records, Calculator
 from taxcalc.utils import (DIST_VARIABLES,
                            DIST_TABLE_COLUMNS, DIST_TABLE_LABELS,
-                           DIFF_VARIABLES,
-                           DIFF_TABLE_COLUMNS, DIFF_TABLE_LABELS,
-                           SOI_AGI_BINS,
+                           STANDARD_INCOME_BINS,
                            create_distribution_table, create_difference_table,
                            weighted_count_lt_zero, weighted_count_gt_zero,
                            weighted_count, weighted_sum,
@@ -49,20 +47,18 @@ DATA_FLOAT = [[1.0, 2, 'a'],
               [3.0, 6, 'b']]
 
 
-def xtest_validity_of_name_lists():
+def test_validity_of_name_lists():
     assert len(DIST_TABLE_COLUMNS) == len(DIST_TABLE_LABELS)
     Records.read_var_info()
     assert set(DIST_VARIABLES).issubset(Records.CALCULATED_VARS | {'weight'})
-    extra_vars_set = set(['num_returns_StandardDed',
-                          'num_returns_ItemDed',
-                          'num_returns_AMT'])
+    extra_vars_set = set()
     assert (set(DIST_TABLE_COLUMNS) - set(DIST_VARIABLES)) == extra_vars_set
 
 
-def xtest_create_tables(pit_subsample):
+def test_create_distribution_tables(pit_fullsample):
     # pylint: disable=too-many-statements,too-many-branches
     # create a current-law Policy object and Calculator object calc1
-    rec = Records(data=pit_subsample)
+    rec = Records(data=pit_fullsample)
     pol = Policy()
     calc1 = Calculator(policy=pol, records=rec)
     calc1.calc_all()
@@ -74,131 +70,27 @@ def xtest_create_tables(pit_subsample):
 
     test_failure = False
 
-    # test creating various difference tables
-
-    diff = create_difference_table(calc1.dataframe(DIFF_VARIABLES),
-                                   calc2.dataframe(DIFF_VARIABLES),
-                                   'standard_income_bins', 'combined')
-    assert isinstance(diff, pd.DataFrame)
-    tabcol = 'pc_aftertaxinc'
-    expected = [np.nan,
-                np.nan,
-                -0.24,
-                -0.79,
-                -0.81,
-                -0.55,
-                -0.77,
-                -0.69,
-                -0.70,
-                -0.67,
-                -0.27,
-                -0.11,
-                -0.06,
-                -0.58]
-    if not np.allclose(diff[tabcol].values, expected,
-                       atol=0.005, rtol=0.0, equal_nan=True):
-        test_failure = True
-        print('diff xbin', tabcol)
-        for val in diff[tabcol].values:
-            print('{:.2f},'.format(val))
-
-    diff = create_difference_table(calc1.dataframe(DIFF_VARIABLES),
-                                   calc2.dataframe(DIFF_VARIABLES),
-                                   'weighted_deciles', 'combined')
-    assert isinstance(diff, pd.DataFrame)
-    tabcol = 'tot_change'
-    expected = [0,
-                0,
-                254095629,
-                2544151690,
-                2826173357,
-                2539574809,
-                4426339426,
-                5178198524,
-                6277367974,
-                8069273960,
-                10572653961,
-                10269542170,
-                52957371499,
-                6188055374,
-                3497187245,
-                584299551]
-    if not np.allclose(diff[tabcol].values, expected,
-                       atol=0.51, rtol=0.0):
-        test_failure = True
-        print('diff xdec', tabcol)
-        for val in diff[tabcol].values:
-            print('{:.0f},'.format(val))
-
-    tabcol = 'share_of_change'
-    expected = [0.00,
-                0.00,
-                0.48,
-                4.80,
-                5.34,
-                4.80,
-                8.36,
-                9.78,
-                11.85,
-                15.24,
-                19.96,
-                19.39,
-                100.00,
-                11.68,
-                6.60,
-                1.10]
-    if not np.allclose(diff[tabcol].values, expected,
-                       atol=0.005, rtol=0.0):
-        test_failure = True
-        print('diff xdec', tabcol)
-        for val in diff[tabcol].values:
-            print('{:.2f},'.format(val))
-
-    tabcol = 'pc_aftertaxinc'
-    expected = [np.nan,
-                np.nan,
-                -0.26,
-                -0.96,
-                -0.74,
-                -0.52,
-                -0.75,
-                -0.71,
-                -0.68,
-                -0.71,
-                -0.71,
-                -0.34,
-                -0.58,
-                -0.61,
-                -0.30,
-                -0.07]
-    if not np.allclose(diff[tabcol].values, expected,
-                       atol=0.005, rtol=0.0, equal_nan=True):
-        test_failure = True
-        print('diff xdec', tabcol)
-        for val in diff[tabcol].values:
-            print('{:.2f},'.format(val))
-
     # test creating various distribution tables
 
     dist, _ = calc2.distribution_tables(None, 'weighted_deciles')
     assert isinstance(dist, pd.DataFrame)
-    tabcol = 'iitax'
+    tabcol = 'pitax'
     expected = [0,
                 0,
-                -1818680093,
-                1971755805,
-                5010676892,
-                6746034269,
-                17979713134,
-                26281107130,
-                35678824858,
-                82705314943,
-                148818900147,
-                734130905355,
-                1057504552440,
-                152370476198,
-                234667184101,
-                347093245055]
+                0,
+                0,
+                0,
+                1962018656,
+                5711348379,
+                14602115060,
+                45502588366,
+                163176554272,
+                397795460459,
+                1018520167211,
+                1647270252404,
+                331217754985,
+                384398972927,
+                302903439300]
     if not np.allclose(dist[tabcol].values, expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
@@ -206,71 +98,23 @@ def xtest_create_tables(pit_subsample):
         for val in dist[tabcol].values:
             print('{:.0f},'.format(val))
 
-    tabcol = 'num_returns_ItemDed'
+    tabcol = 'GTI'
     expected = [0,
                 0,
-                357019,
-                1523252,
-                2463769,
-                2571339,
-                4513934,
-                5278763,
-                6299826,
-                7713038,
-                11001450,
-                13125085,
-                54847474,
-                6188702,
-                5498415,
-                1437967]
-    if not np.allclose(dist[tabcol].tolist(), expected,
-                       atol=0.5, rtol=0.0):
-        test_failure = True
-        print('dist xdec', tabcol)
-        for val in dist[tabcol].values:
-            print('{:.0f},'.format(val))
-
-    tabcol = 'expanded_income'
-    expected = [0,
-                0,
-                105927980655,
-                294023675202,
-                417068113194,
-                528376852001,
-                658853731628,
-                818158430558,
-                1037838578149,
-                1324689584778,
-                1788101751565,
-                4047642990187,
-                11020681687917,
-                1286581399758,
-                1511884268254,
-                1249177322176]
-    if not np.allclose(dist[tabcol].tolist(), expected,
-                       atol=0.5, rtol=0.0):
-        test_failure = True
-        print('dist xdec', tabcol)
-        for val in dist[tabcol].values:
-            print('{:.0f},'.format(val))
-
-    tabcol = 'aftertax_income'
-    expected = [0,
-                0,
-                97735000432,
-                261911925318,
-                378049091828,
-                485619641327,
-                586208937799,
-                722979233740,
-                919208533243,
-                1130705156084,
-                1473967098213,
-                2994484618211,
-                9050869236196,
-                1002450732282,
-                1147596725957,
-                844437159972]
+                688359196193,
+                893686612927,
+                1107005043554,
+                1332669875117,
+                1605579740694,
+                1824545488656,
+                2327660087552,
+                2818092073862,
+                3848954050211,
+                6071568969563,
+                22518121138330,
+                2490655359064,
+                2119235261822,
+                1461678348677]
     if not np.allclose(dist[tabcol].tolist(), expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
@@ -280,21 +124,19 @@ def xtest_create_tables(pit_subsample):
 
     dist, _ = calc2.distribution_tables(None, 'standard_income_bins')
     assert isinstance(dist, pd.DataFrame)
-    tabcol = 'iitax'
+    tabcol = 'pitax'
     expected = [0,
                 0,
-                -544908512,
-                -140959365,
-                3354006293,
-                9339571323,
-                18473567840,
-                55206201916,
-                89276157367,
-                297973932010,
-                290155554334,
-                99528466942,
-                194882962290,
-                1057504552440]
+                8333758171,
+                279112936295,
+                542762267799,
+                401309804350,
+                415751485789,
+                0,
+                0,
+                0,
+                0,
+                1647270252404]
     if not np.allclose(dist[tabcol], expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
@@ -302,161 +144,28 @@ def xtest_create_tables(pit_subsample):
         for val in dist[tabcol].values:
             print('{:.0f},'.format(val))
 
-    tabcol = 'num_returns_ItemDed'
+    tabcol = 'GTI'
     expected = [0,
                 0,
-                60455,
-                1107780,
-                2366845,
-                3460607,
-                4837397,
-                10090391,
-                8850784,
-                17041135,
-                6187168,
-                532925,
-                311987,
-                54847474]
+                5884790064186,
+                7399791669944,
+                4810525909565,
+                2392643281013,
+                2030370213621,
+                0,
+                0,
+                0,
+                0,
+                22518121138330]
     if not np.allclose(dist[tabcol].tolist(), expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
-        print('dist xbin', tabcol)
+        print('dist xdec', tabcol)
         for val in dist[tabcol].values:
             print('{:.0f},'.format(val))
 
     if test_failure:
         assert 1 == 2
-
-
-def test_diff_count_precision():
-    """
-    Estimate bootstrap standard error and confidence interval for count
-    statistics ('tax_cut' and 'tax_inc') in difference table generated
-    using puf.csv input data taking no account of tbi privacy fuzzing and
-    assuming all filing units in each bin have the same weight.  These
-    assumptions imply that the estimates produced here are likely to
-    over-estimate the precision of the count statistics.
-
-    Background information on unweighted number of filing units by bin:
-
-    DECILE BINS:
-    0   16268
-    1   14897
-    2   13620
-    3   15760
-    4   16426
-    5   18070
-    6   18348
-    7   19352
-    8   21051
-    9   61733 <--- largest unweighted bin count
-    A  215525
-
-    STANDARD BINS:
-    0    7081 <--- negative income bin is dropped in TaxBrain display
-    1   19355
-    2   22722
-    3   20098
-    4   17088
-    5   14515
-    6   24760
-    7   15875
-    8   25225
-    9   15123
-    10  10570 <--- smallest unweighted bin count
-    11  23113 <--- second largest unweighted WEBAPP bin count
-    A  215525
-
-    Background information on Trump2017.json reform used in TaxBrain run 16649:
-
-    STANDARD bin 10 ($500-1000 thousand) has weighted count of 1179 thousand;
-                    weighted count of units with tax increase is 32 thousand.
-
-    So, the mean weight for all units in STANDARD bin 10 is 111.5421 and the
-    unweighted number with a tax increase is 287 assuming all units in that
-    bin have the same weight.  (Note that 287 * 111.5421 is about 32,012.58,
-    which rounds to the 32 thousand shown in the TaxBrain difference table.)
-
-    STANDARD bin 11 ($1000+ thousand) has weighted count of 636 thousand;
-                    weighted count of units with tax increase is 27 thousand.
-
-    So, the mean weight for all units in STANDARD bin 11 is about 27.517 and
-    the unweighted number with a tax increase is 981 assuming all units in
-    that bin have the same weight.  (Note that 981 * 27.517 is about 26,994.18,
-    which rounds to the 27 thousand shown in the TaxBrain difference table.)
-    """
-    dump = False  # setting to True implies results printed and test fails
-    seed = 123456789
-    bs_samples = 1000
-    alpha = 0.025  # implies 95% confidence interval
-    # compute stderr and confidence interval for STANDARD bin 10 increase count
-    data_list = [111.5421] * 287 + [0.0] * (10570 - 287)
-    assert len(data_list) == 10570
-    data = np.array(data_list)
-    assert (data > 0).sum() == 287
-    data_estimate = np.sum(data) * 1e-3
-    assert abs((data_estimate / 32) - 1) < 0.0005
-    bsd = bootstrap_se_ci(data, seed, bs_samples, np.sum, alpha)
-    stderr = bsd['se'] * 1e-3
-    cilo = bsd['cilo'] * 1e-3
-    cihi = bsd['cihi'] * 1e-3
-    if dump:
-        res = '{}EST={:.1f} B={} alpha={:.3f} se={:.2f} ci=[ {:.2f} , {:.2f} ]'
-        print(
-            res.format('STANDARD-BIN10: ',
-                       data_estimate, bs_samples, alpha, stderr, cilo, cihi)
-        )
-    assert abs((stderr / 1.90) - 1) < 0.0008
-    # NOTE: a se of 1.90 thousand implies that when comparing the difference
-    #       in the weighted number of filing units in STANDARD bin 10 with a
-    #       tax increase, the difference statistic has a bigger se (because
-    #       the variance of the difference is the sum of the variances of the
-    #       two point estimates).  So, in STANDARD bin 10 if the point
-    #       estimates both had se = 1.90, then the difference in the point
-    #       estimates has has a se = 2.687.  This means that the difference
-    #       would have to be over 5 thousand in order for there to be high
-    #       confidence that the difference was different from zero in a
-    #       statistically significant manner.
-    #       Or put a different way, a difference of 1 thousand cannot be
-    #       accurately detected while a difference of 10 thousand can be
-    #       accurately detected.
-    assert abs((cilo / 28.33) - 1) < 0.0012
-    assert abs((cihi / 35.81) - 1) < 0.0012
-    # compute stderr and confidence interval for STANDARD bin 11 increase count
-    data_list = [27.517] * 981 + [0.0] * (23113 - 981)
-    assert len(data_list) == 23113
-    data = np.array(data_list)
-    assert (data > 0).sum() == 981
-    data_estimate = np.sum(data) * 1e-3
-    assert abs((data_estimate / 27) - 1) < 0.0005
-    bsd = bootstrap_se_ci(data, seed, bs_samples, np.sum, alpha)
-    stderr = bsd['se'] * 1e-3
-    cilo = bsd['cilo'] * 1e-3
-    cihi = bsd['cihi'] * 1e-3
-    if dump:
-        res = '{}EST={:.1f} B={} alpha={:.3f} se={:.2f} ci=[ {:.2f} , {:.2f} ]'
-        print(
-            res.format('STANDARD-BIN11: ',
-                       data_estimate, bs_samples, alpha, stderr, cilo, cihi)
-        )
-    assert abs((stderr / 0.85) - 1) < 0.0040
-    # NOTE: a se of 0.85 thousand implies that when comparing the difference
-    #       in the weighted number of filing units in STANDARD bin 11 with a
-    #       tax increase, the difference statistic has a bigger se (because
-    #       the variance of the difference is the sum of the variances of the
-    #       two point estimates).  So, in STANDARD bin 11 if point estimates
-    #       both had se = 0.85, then the difference in the point estimates has
-    #       has a se = 1.20.  This means that the difference would have to be
-    #       over 2.5 thousand in order for there to be high confidence that the
-    #       difference was different from zero in a statistically significant
-    #       manner.
-    #       Or put a different way, a difference of 1 thousand cannot be
-    #       accurately detected while a difference of 10 thousand can be
-    #       accurately detected.
-    assert abs((cilo / 25.37) - 1) < 0.0012
-    assert abs((cihi / 28.65) - 1) < 0.0012
-    # fail if doing dump
-    assert not dump
 
 
 def test_weighted_count_lt_zero():
@@ -513,13 +222,13 @@ EPSILON = 1e-5
 
 def test_add_income_trow_var():
     dta = np.arange(1, 1e6, 5000)
-    vdf = pd.DataFrame(data=dta, columns=['expanded_income'])
-    vdf = add_income_table_row_variable(vdf, 'expanded_income', SOI_AGI_BINS)
+    vdf = pd.DataFrame(data=dta, columns=['GTI'])
+    vdf = add_income_table_row_variable(vdf, 'GTI', STANDARD_INCOME_BINS)
     gdf = vdf.groupby('table_row')
     idx = 1
     for name, _ in gdf:
         assert name.closed == 'left'
-        assert abs(name.right - SOI_AGI_BINS[idx]) < EPSILON
+        assert abs(name.right - STANDARD_INCOME_BINS[idx]) < EPSILON
         idx += 1
 
 
@@ -541,41 +250,17 @@ def test_add_quantile_trow_var():
                                               100, decile_details=True)
 
 
-def xtest_dist_table_sum_row(pit_subsample):
+def test_dist_table_sum_row(pit_subsample):
     rec = Records(data=pit_subsample)
     calc = Calculator(policy=Policy(), records=rec)
     calc.calc_all()
     tb1 = create_distribution_table(calc.distribution_table_dataframe(),
-                                    'standard_income_bins', 'expanded_income')
+                                    'standard_income_bins', 'GTI')
     tb2 = create_distribution_table(calc.distribution_table_dataframe(),
-                                    'soi_agi_bins', 'expanded_income')
-    assert np.allclose(tb1[-1:], tb2[-1:])
-
-
-def xtest_diff_table_sum_row(pit_subsample):
-    rec = Records(data=pit_subsample)
-    # create a current-law Policy object and Calculator calc1
-    pol = Policy()
-    calc1 = Calculator(policy=pol, records=rec)
-    calc1.calc_all()
-    # create a policy-reform Policy object and Calculator calc2
-    reform = {2017: {'_rate2': [0.06]}}
-    pol.implement_reform(reform)
-    calc2 = Calculator(policy=pol, records=rec)
-    calc2.calc_all()
-    # create two difference tables and compare their content
-    tdiff1 = create_difference_table(calc1.dataframe(DIFF_VARIABLES),
-                                     calc2.dataframe(DIFF_VARIABLES),
-                                     'standard_income_bins', 'iitax')
-    tdiff2 = create_difference_table(calc1.dataframe(DIFF_VARIABLES),
-                                     calc2.dataframe(DIFF_VARIABLES),
-                                     'soi_agi_bins', 'iitax')
-    non_digit_cols = ['perc_inc', 'perc_cut']
-    digit_cols = [c for c in list(tdiff1) if c not in non_digit_cols]
-    assert np.allclose(tdiff1[digit_cols][-1:],
-                       tdiff2[digit_cols][-1:])
-    np.allclose(tdiff1[non_digit_cols][-1:],
-                tdiff2[non_digit_cols][-1:])
+                                    'weighted_deciles', 'GTI')
+    allrow1 = tb1[-1:]
+    allrow2 = tb2[-4:-3]
+    assert np.allclose(allrow1, allrow2)
 
 
 def test_read_egg_csv():
@@ -606,7 +291,6 @@ def test_bootstrap_se_ci():
 def test_table_columns_labels():
     # check that length of two lists are the same
     assert len(DIST_TABLE_COLUMNS) == len(DIST_TABLE_LABELS)
-    assert len(DIFF_TABLE_COLUMNS) == len(DIFF_TABLE_LABELS)
 
 
 def test_nonsmall_diffs():

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -22,95 +22,25 @@ from taxcalc.utilsprvt import (weighted_count_lt_zero,
 # DIST_TABLE_LABELS list below; this correspondence allows us to use this
 # labels list to map a label to the correct column in a distribution table.
 
-DIST_VARIABLES = ['expanded_income', 'c00100', 'aftertax_income', 'standard',
-                  'c04470', 'c04600', 'c04800', 'taxbc', 'c62100', 'c09600',
-                  'c05800', 'othertaxes', 'refund', 'c07100',
-                  'iitax', 'payrolltax', 'combined', 'weight', 'ubi',
-                  'benefit_cost_total', 'benefit_value_total']
+DIST_VARIABLES = ['weight', 'GTI', 'TTI',
+                  'TI_special_rates', 'tax_TI_special_rates',
+                  'Aggregate_Income', 'tax_Aggregate_Income',
+                  'tax_TTI', 'rebate', 'surcharge', 'cess', 'pitax']
 
-DIST_TABLE_COLUMNS = ['weight',
-                      'c00100',
-                      'num_returns_StandardDed',
-                      'standard',
-                      'num_returns_ItemDed',
-                      'c04470',
-                      'c04600',
-                      'c04800',
-                      'taxbc',
-                      'c62100',
-                      'num_returns_AMT',
-                      'c09600',
-                      'c05800',
-                      'c07100',
-                      'othertaxes',
-                      'refund',
-                      'iitax',
-                      'payrolltax',
-                      'combined',
-                      'ubi',
-                      'benefit_cost_total',
-                      'benefit_value_total',
-                      'expanded_income',
-                      'aftertax_income']
+DIST_TABLE_COLUMNS = DIST_VARIABLES
 
 DIST_TABLE_LABELS = ['Returns',
-                     'AGI',
-                     'Standard Deduction Filers',
-                     'Standard Deduction',
-                     'Itemizers',
-                     'Itemized Deduction',
-                     'Personal Exemption',
-                     'Taxable Income',
-                     'Regular Tax',
-                     'AMTI',
-                     'AMT Filers',
-                     'AMT',
-                     'Tax before Credits',
-                     'Non-refundable Credits',
-                     'Other Taxes',
-                     'Refundable Credits',
-                     'Individual Income Tax Liabilities',
-                     'Payroll Tax Liablities',
-                     'Combined Payroll and Individual Income Tax Liabilities',
-                     'Universal Basic Income',
-                     'Total Cost of Benefits',
-                     'Consumption Value of Benefits',
-                     'Expanded Income',
-                     'After-Tax Expanded Income']
-
-# Items in the DIFF_TABLE_COLUMNS list below correspond to the items in the
-# DIFF_TABLE_LABELS list below; this correspondence allows us to use this
-# labels list to map a label to the correct column in a difference table.
-
-DIFF_VARIABLES = ['expanded_income', 'c00100', 'aftertax_income',
-                  'iitax', 'payrolltax', 'combined', 'weight', 'ubi',
-                  'benefit_cost_total', 'benefit_value_total']
-
-DIFF_TABLE_COLUMNS = ['count',
-                      'tax_cut',
-                      'perc_cut',
-                      'tax_inc',
-                      'perc_inc',
-                      'mean',
-                      'tot_change',
-                      'share_of_change',
-                      'ubi',
-                      'benefit_cost_total',
-                      'benefit_value_total',
-                      'pc_aftertaxinc']
-
-DIFF_TABLE_LABELS = ['All Tax Units',
-                     'Tax Units with Tax Cut',
-                     'Percent with Tax Cut',
-                     'Tax Units with Tax Increase',
-                     'Percent with Tax Increase',
-                     'Average Tax Change',
-                     'Total Tax Difference',
-                     'Share of Overall Change',
-                     'Universal Basic Income',
-                     'Total Cost of Benefits',
-                     'Consumption Value of Benefits',
-                     '% Change in After-Tax Income']
+                     'GTI',
+                     'TTI All',
+                     'TTI @ Special Rates',
+                     'Tax @ Special Rates',
+                     'TTI @ Normal Rates',
+                     'Tax @ Normal Rates',
+                     'Tax on TTI',
+                     'Rebate',
+                     'Surcharge',
+                     'CESS',
+                     'PITax']
 
 DECILE_ROW_NAMES = ['0-10n', '0-10z', '0-10p',
                     '10-20', '20-30', '30-40', '40-50',
@@ -118,15 +48,12 @@ DECILE_ROW_NAMES = ['0-10n', '0-10z', '0-10p',
                     'ALL',
                     '90-95', '95-99', 'Top 1%']
 
-STANDARD_ROW_NAMES = ['<$0K', '=$0K', '$0-10K', '$10-20K', '$20-30K',
-                      '$30-40K', '$40-50K', '$50-75K', '$75-100K',
-                      '$100-200K', '$200-500K', '$500-1000K', '>$1000K', 'ALL']
+STANDARD_ROW_NAMES = ['<0', '=0', '0-5L', '5-10L', '10-15L',
+                      '15-20L', '20-30L', '30-40L', '40-50L',
+                      '50-100L', '>100L', 'ALL']
 
-STANDARD_INCOME_BINS = [-9e99, -1e-9, 1e-9, 10e3, 20e3, 30e3, 40e3, 50e3,
-                        75e3, 100e3, 200e3, 500e3, 1e6, 9e99]
-
-SOI_AGI_BINS = [-9e99, 1.0, 5e3, 10e3, 15e3, 20e3, 25e3, 30e3, 40e3, 50e3,
-                75e3, 100e3, 200e3, 500e3, 1e6, 1.5e6, 2e6, 5e6, 10e6, 9e99]
+STANDARD_INCOME_BINS = [-9e99, -1e-9, 1e-9, 5e5, 10e5, 15e5, 20e5, 30e5,
+                        40e5, 50e5, 100e5, 9e99]
 
 
 def unweighted_sum(pdf, col_name):
@@ -250,7 +177,7 @@ def create_distribution_table(vdf, groupby, income_measure):
 
     groupby : String object
         options for input: 'weighted_deciles' or
-                           'standard_income_bins' or 'soi_agi_bins'
+                           'standard_income_bins'
         determines how the rows in the resulting Pandas DataFrame are sorted
 
     income_measure: String object
@@ -279,8 +206,7 @@ def create_distribution_table(vdf, groupby, income_measure):
         Returns calculated distribution table column statistics derived from
         the specified grouped Dataframe object, gpdf.
         """
-        unweighted_columns = ['weight', 'num_returns_StandardDed',
-                              'num_returns_ItemDed', 'num_returns_AMT']
+        unweighted_columns = ['weight']
         sdf = pd.DataFrame()
         for col in DIST_TABLE_COLUMNS:
             if col in unweighted_columns:
@@ -291,10 +217,9 @@ def create_distribution_table(vdf, groupby, income_measure):
     # main logic of create_distribution_table
     assert isinstance(vdf, pd.DataFrame)
     assert (groupby == 'weighted_deciles' or
-            groupby == 'standard_income_bins' or
-            groupby == 'soi_agi_bins')
-    assert (income_measure == 'expanded_income' or
-            income_measure == 'expanded_income_baseline')
+            groupby == 'standard_income_bins')
+    assert (income_measure == 'GTI' or
+            income_measure == 'GTI_baseline')
     assert income_measure in vdf
     assert 'table_row' not in list(vdf.columns.values)
     # sort the data given specified groupby and income_measure
@@ -304,9 +229,6 @@ def create_distribution_table(vdf, groupby, income_measure):
     elif groupby == 'standard_income_bins':
         pdf = add_income_table_row_variable(vdf, income_measure,
                                             STANDARD_INCOME_BINS)
-    elif groupby == 'soi_agi_bins':
-        pdf = add_income_table_row_variable(vdf, income_measure,
-                                            SOI_AGI_BINS)
     # construct grouped DataFrame
     gpdf = pdf.groupby('table_row', as_index=False)
     dist_table = stat_dataframe(gpdf)
@@ -511,118 +433,6 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff):
     vdf1.sort_index(inplace=True)
     vdf2.sort_index(inplace=True)
     return diff_table
-
-
-def create_diagnostic_table(vdf, year):
-    """
-    Extract single-year diagnostic table from Pandas DataFrame object
-    derived from a Calculator object using the dataframe(DIST_VARIABLES)
-    method.
-
-    Parameters
-    ----------
-    vdf : Pandas DataFrame object containing the variables
-
-    year : assessment year for which variables are drawn from Calculator object
-
-    Returns
-    -------
-    Pandas DataFrame object containing the diagnostic table
-    """
-    # pylint: disable=too-many-statements
-    def diagnostic_table_odict(recs):
-        """
-        Nested function that extracts diagnostic table dictionary from
-        the specified Pandas DataFrame object, vdf.
-
-        Parameters
-        ----------
-        vdf : Pandas DataFrame object containing the variables
-
-        Returns
-        -------
-        ordered dictionary of variable names and aggregate weighted values
-        """
-        # aggregate weighted values expressed in millions or billions
-        in_millions = 1.0e-6
-        in_billions = 1.0e-9
-        odict = collections.OrderedDict()
-        # total number of filing units
-        wghts = vdf['weight']
-        odict['Returns (#m)'] = wghts.sum() * in_millions
-        # adjusted gross income
-        agi = vdf['c00100']
-        odict['AGI ($b)'] = (agi * wghts).sum() * in_billions
-        # number of itemizers
-        num = (wghts[vdf['c04470'] > 0.].sum())
-        odict['Itemizers (#m)'] = num * in_millions
-        # itemized deduction
-        ided1 = vdf['c04470'] * wghts
-        val = ided1[vdf['c04470'] > 0.].sum()
-        odict['Itemized Deduction ($b)'] = val * in_billions
-        # number of standard deductions
-        num = wghts[vdf['standard'] > 0.].sum()
-        odict['Standard Deduction Filers (#m)'] = num * in_millions
-        # standard deduction
-        sded1 = recs.standard * wghts
-        val = sded1[vdf['standard'] > 0.].sum()
-        odict['Standard Deduction ($b)'] = val * in_billions
-        # personal exemption
-        val = (vdf['c04600'] * wghts).sum()
-        odict['Personal Exemption ($b)'] = val * in_billions
-        # taxable income
-        val = (vdf['c04800'] * wghts).sum()
-        odict['Taxable Income ($b)'] = val * in_billions
-        # regular tax liability
-        val = (vdf['taxbc'] * wghts).sum()
-        odict['Regular Tax ($b)'] = val * in_billions
-        # AMT taxable income
-        odict['AMT Income ($b)'] = ((vdf['c62100'] * wghts).sum() *
-                                    in_billions)
-        # total AMT liability
-        odict['AMT Liability ($b)'] = ((vdf['c09600'] * wghts).sum() *
-                                       in_billions)
-        # number of people paying AMT
-        odict['AMT Filers (#m)'] = (wghts[vdf['c09600'] > 0.].sum() *
-                                    in_millions)
-        # tax before credits
-        val = (vdf['c05800'] * wghts).sum()
-        odict['Tax before Credits ($b)'] = val * in_billions
-        # refundable credits
-        val = (vdf['refund'] * wghts).sum()
-        odict['Refundable Credits ($b)'] = val * in_billions
-        # nonrefundable credits
-        val = (vdf['c07100'] * wghts).sum()
-        odict['Nonrefundable Credits ($b)'] = val * in_billions
-        # reform surtaxes (part of federal individual income tax liability)
-        val = (vdf['surtax'] * wghts).sum()
-        odict['Reform Surtaxes ($b)'] = val * in_billions
-        # other taxes on Form 1040
-        val = (vdf['othertaxes'] * wghts).sum()
-        odict['Other Taxes ($b)'] = val * in_billions
-        # federal individual income tax liability
-        val = (vdf['iitax'] * wghts).sum()
-        odict['Ind Income Tax ($b)'] = val * in_billions
-        # OASDI+HI payroll tax liability (including employer share)
-        val = (vdf['payrolltax'] * wghts).sum()
-        odict['Payroll Taxes ($b)'] = val * in_billions
-        # combined income and payroll tax liability
-        val = (vdf['combined'] * wghts).sum()
-        odict['Combined Liability ($b)'] = val * in_billions
-        # number of tax units with non-positive income tax liability
-        num = (wghts[vdf['iitax'] <= 0]).sum()
-        odict['With Income Tax <= 0 (#m)'] = num * in_millions
-        # number of tax units with non-positive combined tax liability
-        num = (wghts[vdf['combined'] <= 0]).sum()
-        odict['With Combined Tax <= 0 (#m)'] = num * in_millions
-        return odict
-    # tabulate diagnostic table
-    odict = diagnostic_table_odict(vdf)
-    pdf = pd.DataFrame(data=odict, index=[year], columns=odict.keys())
-    pdf = pdf.transpose()
-    pd.options.display.float_format = '{:8,.1f}'.format
-    del odict
-    return pdf
 
 
 def read_egg_csv(fname, index_col=None):


### PR DESCRIPTION
This pull request resolves issue #65 by adding distribution tables to the PITax calculator.  The subgroups are sorted by GTI.

Here is an example of the use of the new capability:
```
# dist-tables.py

import taxcalc as tc

# create current-law Calculator object calc1
rec = tc.Records()
pol = tc.Policy()
calc1 = tc.Calculator(policy=pol, records=rec)
assert calc1.current_year == 2017
calc1.calc_all()

# create policy-reform Calculator object calc2
reform = {2017: {'_rate2': [0.06]}}  # reform lowers rate from 10% to 6%
pol.implement_reform(reform)
calc2 = tc.Calculator(policy=pol, records=rec)
calc2.calc_all()
assert calc2.current_year == 2017

# create decile distribution tables for current law and policy reform
dt1, dt2 = calc1.distribution_tables(calc2, 'weighted_deciles')
print('Current-Law Distribution Table for 2017')
print(dt1)
print('Policy-Reform Distribution Table for 2017')
print(dt2)

"""
$ python dist-tables.py

Current-Law Distribution Table for 2017
           weight        ...                    pitax
0-10n           0        ...                        0
0-10z           0        ...                        0
0-10p   3,524,118        ...                        0
10-20   3,341,251        ...                        0
20-30   3,515,237        ...            1,540,277,852
30-40   3,515,237        ...            8,907,038,916
40-50   3,532,998        ...           17,064,193,114
50-60   3,524,118        ...           34,646,345,675
60-70   3,702,544        ...           75,783,006,310
70-80   3,524,118        ...          199,116,555,010
80-90   3,528,558        ...          432,866,876,267
90-100  3,532,998        ...        1,052,194,529,418
ALL    35,241,176        ...        1,822,118,822,561
90-95   1,766,499        ...          348,139,965,152
95-99   1,148,668        ...          395,334,232,019
Top 1%    617,831        ...          308,720,332,246


Policy-Reform Distribution Table for 2017
           weight        ...                    pitax
0-10n           0        ...                        0
0-10z           0        ...                        0
0-10p   3,524,118        ...                        0
10-20   3,341,251        ...                        0
20-30   3,515,237        ...                        0
30-40   3,515,237        ...            1,962,018,656
40-50   3,532,998        ...            5,711,348,379
50-60   3,524,118        ...           14,602,115,060
60-70   3,702,544        ...           45,502,588,366
70-80   3,524,118        ...          163,176,554,272
80-90   3,528,558        ...          397,795,460,459
90-100  3,532,998        ...        1,018,520,167,211
ALL    35,241,176        ...        1,647,270,252,404
90-95   1,766,499        ...          331,217,754,985
95-99   1,148,668        ...          384,398,972,927
Top 1%    617,831        ...          302,903,439,300
"""
```
