### PR TITLE
Add options to Calculator.distribution_tables method

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -332,7 +332,7 @@ class Calculator(object):
         del diag
         return pd.concat(tlist, axis=1)
 
-    def distribution_tables(self, calc, groupby):
+    def distribution_tables(self, calc, groupby, averages=False):
         """
         Get results from self and calc, sort them by GTI into table
         rows defined by groupby, compute grouped statistics, and
@@ -351,6 +351,10 @@ class Calculator(object):
         groupby : String object
             options for input: 'weighted_deciles', 'standard_income_bins'
             determines how the columns in resulting Pandas DataFrame are sorted
+
+        averages : boolean
+            specifies whether or not monetary table entries are aggregates or
+            averages (default value of False implies entries are aggregates)
 
         Return and typical usage
         ------------------------
@@ -391,7 +395,8 @@ class Calculator(object):
                                calc.array('weight'))  # rows in same order
         var_dataframe = self.distribution_table_dataframe()
         imeasure = 'GTI'
-        dt1 = create_distribution_table(var_dataframe, groupby, imeasure)
+        dt1 = create_distribution_table(var_dataframe, groupby, imeasure,
+                                        averages)
         del var_dataframe
         if calc is None:
             dt2 = None
@@ -404,7 +409,8 @@ class Calculator(object):
             else:
                 imeasure = 'GTI_baseline'
                 var_dataframe[imeasure] = self.array('GTI')
-            dt2 = create_distribution_table(var_dataframe, groupby, imeasure)
+            dt2 = create_distribution_table(var_dataframe, groupby, imeasure,
+                                            averages)
             del var_dataframe
         return (dt1, dt2)
 

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -332,7 +332,8 @@ class Calculator(object):
         del diag
         return pd.concat(tlist, axis=1)
 
-    def distribution_tables(self, calc, groupby, averages=False):
+    def distribution_tables(self, calc, groupby,
+                            averages=False, scaling=True):
         """
         Get results from self and calc, sort them by GTI into table
         rows defined by groupby, compute grouped statistics, and
@@ -355,6 +356,14 @@ class Calculator(object):
         averages : boolean
             specifies whether or not monetary table entries are aggregates or
             averages (default value of False implies entries are aggregates)
+
+        scaling : boolean
+            specifies whether or not monetary table entries are scaled to
+            billions and rounded to three decimal places when averages=False,
+            or when averages=True, to thousands and rounded to three decimal
+            places.  Regardless of the value of averages, non-monetary table
+            entries are scaled to millions and rounded to three decimal places
+            (default value of False implies entries are scaled and rounded)
 
         Return and typical usage
         ------------------------
@@ -396,7 +405,7 @@ class Calculator(object):
         var_dataframe = self.distribution_table_dataframe()
         imeasure = 'GTI'
         dt1 = create_distribution_table(var_dataframe, groupby, imeasure,
-                                        averages)
+                                        averages, scaling)
         del var_dataframe
         if calc is None:
             dt2 = None
@@ -410,7 +419,7 @@ class Calculator(object):
                 imeasure = 'GTI_baseline'
                 var_dataframe[imeasure] = self.array('GTI')
             dt2 = create_distribution_table(var_dataframe, groupby, imeasure,
-                                            averages)
+                                            averages, scaling)
             del var_dataframe
         return (dt1, dt2)
 

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -91,8 +91,7 @@ def test_create_distribution_tables(pit_fullsample):
                 331.218,
                 384.399,
                 302.903]
-    if not np.allclose(dist[tabcol].values, expected,
-                       atol=0.5, rtol=0.0):
+    if not np.allclose(dist[tabcol].values, expected):
         test_failure = True
         print('dist xdec', tabcol)
         for val in dist[tabcol].values:
@@ -115,8 +114,7 @@ def test_create_distribution_tables(pit_fullsample):
                 2490.655,
                 2119.235,
                 1461.678]
-    if not np.allclose(dist[tabcol].tolist(), expected,
-                       atol=0.5, rtol=0.0):
+    if not np.allclose(dist[tabcol].tolist(), expected):
         test_failure = True
         print('dist xdec', tabcol)
         for val in dist[tabcol].values:
@@ -137,8 +135,7 @@ def test_create_distribution_tables(pit_fullsample):
                 0.000,
                 0.000,
                 1647.270]
-    if not np.allclose(dist[tabcol], expected,
-                       atol=0.5, rtol=0.0):
+    if not np.allclose(dist[tabcol], expected):
         test_failure = True
         print('dist xbin', tabcol)
         for val in dist[tabcol].values:
@@ -157,8 +154,7 @@ def test_create_distribution_tables(pit_fullsample):
                 0.000,
                 0.000,
                 22518.121]
-    if not np.allclose(dist[tabcol].tolist(), expected,
-                       atol=0.5, rtol=0.0):
+    if not np.allclose(dist[tabcol].tolist(), expected):
         test_failure = True
         print('dist xdec', tabcol)
         for val in dist[tabcol].values:

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -75,94 +75,94 @@ def test_create_distribution_tables(pit_fullsample):
     dist, _ = calc2.distribution_tables(None, 'weighted_deciles')
     assert isinstance(dist, pd.DataFrame)
     tabcol = 'pitax'
-    expected = [0,
-                0,
-                0,
-                0,
-                0,
-                1962018656,
-                5711348379,
-                14602115060,
-                45502588366,
-                163176554272,
-                397795460459,
-                1018520167211,
-                1647270252404,
-                331217754985,
-                384398972927,
-                302903439300]
+    expected = [0.000,
+                0.000,
+                0.000,
+                0.000,
+                0.000,
+                1.962,
+                5.711,
+                14.602,
+                45.503,
+                163.177,
+                397.795,
+                1018.520,
+                1647.270,
+                331.218,
+                384.399,
+                302.903]
     if not np.allclose(dist[tabcol].values, expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
         print('dist xdec', tabcol)
         for val in dist[tabcol].values:
-            print('{:.0f},'.format(val))
+            print('{:.3f},'.format(val))
 
     tabcol = 'GTI'
-    expected = [0,
-                0,
-                688359196193,
-                893686612927,
-                1107005043554,
-                1332669875117,
-                1605579740694,
-                1824545488656,
-                2327660087552,
-                2818092073862,
-                3848954050211,
-                6071568969563,
-                22518121138330,
-                2490655359064,
-                2119235261822,
-                1461678348677]
+    expected = [0.000,
+                0.000,
+                688.359,
+                893.687,
+                1107.005,
+                1332.670,
+                1605.580,
+                1824.545,
+                2327.660,
+                2818.092,
+                3848.954,
+                6071.569,
+                22518.121,
+                2490.655,
+                2119.235,
+                1461.678]
     if not np.allclose(dist[tabcol].tolist(), expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
         print('dist xdec', tabcol)
         for val in dist[tabcol].values:
-            print('{:.0f},'.format(val))
+            print('{:.3f},'.format(val))
 
     dist, _ = calc2.distribution_tables(None, 'standard_income_bins')
     assert isinstance(dist, pd.DataFrame)
     tabcol = 'pitax'
-    expected = [0,
-                0,
-                8333758171,
-                279112936295,
-                542762267799,
-                401309804350,
-                415751485789,
-                0,
-                0,
-                0,
-                0,
-                1647270252404]
+    expected = [0.000,
+                0.000,
+                8.334,
+                279.113,
+                542.762,
+                401.310,
+                415.751,
+                0.000,
+                0.000,
+                0.000,
+                0.000,
+                1647.270]
     if not np.allclose(dist[tabcol], expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
         print('dist xbin', tabcol)
         for val in dist[tabcol].values:
-            print('{:.0f},'.format(val))
+            print('{:.3f},'.format(val))
 
     tabcol = 'GTI'
-    expected = [0,
-                0,
-                5884790064186,
-                7399791669944,
-                4810525909565,
-                2392643281013,
-                2030370213621,
-                0,
-                0,
-                0,
-                0,
-                22518121138330]
+    expected = [0.000,
+                0.000,
+                5884.790,
+                7399.792,
+                4810.526,
+                2392.643,
+                2030.370,
+                0.000,
+                0.000,
+                0.000,
+                0.000,
+                22518.121]
     if not np.allclose(dist[tabcol].tolist(), expected,
                        atol=0.5, rtol=0.0):
         test_failure = True
         print('dist xdec', tabcol)
         for val in dist[tabcol].values:
-            print('{:.0f},'.format(val))
+            print('{:.3f},'.format(val))
 
     if test_failure:
         assert 1 == 2

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -165,10 +165,11 @@ def get_sums(pdf):
 
 
 def create_distribution_table(vdf, groupby, income_measure,
-                              averages=False):
+                              averages=False, scaling=True):
     """
     Get results from vdf, sort them by expanded_income based on groupby,
-    and return them as a table.
+    and return them as a table containing entries as specified by the
+    averages and scaling options.
 
     Parameters
     ----------
@@ -188,6 +189,14 @@ def create_distribution_table(vdf, groupby, income_measure,
     averages : boolean
         specifies whether or not monetary table entries are aggregates or
         averages (default value of False implies entries are aggregates)
+
+    scaling : boolean
+        specifies whether or not monetary table entries are scaled to
+        billions and rounded to three decimal places when averages=False,
+        or when averages=True, to thousands and rounded to three decimal
+        places.  Regardless of the value of averages, non-monetary table
+        entries are scaled to millions and rounded to three decimal places
+        (default value of False implies entries are scaled and rounded)
 
     Returns
     -------
@@ -278,6 +287,17 @@ def create_distribution_table(vdf, groupby, income_measure,
         for col in DIST_TABLE_COLUMNS:
             if col != 'weight':
                 dist_table[col] /= dist_table['weight']
+
+    # optionally scale and round table entries
+    if scaling:
+        for col in DIST_TABLE_COLUMNS:
+            if col == 'weight':
+                dist_table[col] = np.round(dist_table[col] * 1e-6, 3)
+            else:
+                if averages:
+                    dist_table[col] = np.round(dist_table[col] * 1e-3, 3)
+                else:
+                    dist_table[col] = np.round(dist_table[col] * 1e-9, 3)
     # return table as Pandas DataFrame
     vdf.sort_index(inplace=True)
     return dist_table


### PR DESCRIPTION
This pull request adds two arguments to the `Calculator.distribution_tables` method.
This pull request resolves issue #84.  

The first option is called `averages` and it has a default value of False.  When set to True, the monetary entries in the distribution tables are weighted averages rather than aggregate totals.

The second option is called `scaling` and it has a default value of True.  When set to True, the monetary entries in the distribution tables are scaled and rounded as follows:
- when `averages` is False, scaled to billions and rounded to three decimal places
- when `averages` is True, scaled to thousands and rounded to three decimal places

Regardless of the value of `averages`, non-monetary entries in the distribution tables are scaled to millions and rounded to three decimal places when `scaling` is True.

Using the default values of these two new arguments, we get the following results in the `dist-table-part-ref.txt` file when executing the Python script below the results:
```
        weight        GTI        TTI     pitax
0-10n    0.000      0.000      0.000     0.000
0-10z    0.000      0.000      0.000     0.000
0-10p    3.524    688.359    586.062     0.000
10-20    3.341    893.687    842.844     0.000
20-30    3.515   1107.005   1011.919     0.000
30-40    3.515   1332.670   1101.027     1.962
40-50    3.533   1605.580   1267.190     5.711
50-60    3.524   1824.545   1393.080    14.602
60-70    3.703   2327.660   1719.754    45.503
70-80    3.524   2818.092   2293.053   163.177
80-90    3.529   3848.954   3375.577   397.795
90-100   3.533   6071.569   5487.600  1018.520
ALL     35.241  22518.121  19078.106  1647.270
90-95    1.766   2490.655   2174.374   331.218
95-99    1.149   2119.235   1945.226   384.399
Top 1%   0.618   1461.678   1368.000   302.903
```
Here is the Python script that generates the above results:
```
import taxcalc as tc

# create current-law Calculator object calc1
rec = tc.Records()
pol = tc.Policy()
calc1 = tc.Calculator(policy=pol, records=rec)
assert calc1.current_year == 2017
calc1.calc_all()

# create policy-reform Calculator object calc2
reform = {2017: {'_rate2': [0.06]}}  # reform lowers rate from 10% to 6%
pol.implement_reform(reform)
calc2 = tc.Calculator(policy=pol, records=rec)
calc2.calc_all()
assert calc2.current_year == 2017

# create decile distribution tables for current law and policy reform
dt1, dt2 = calc1.distribution_tables(calc2, 'weighted_deciles')

# print text version of each complete distribution table to a file
with open('dist-table-all-clp.txt', 'w') as dfile:
    dt1.to_string(dfile)
with open('dist-table-all-ref.txt', 'w') as dfile:    
    dt2.to_string(dfile)

# print text version of each partial distribution table to a file
to_include = ['weight', 'GTI', 'TTI', 'pitax']
with open('dist-table-part-clp.txt', 'w') as dfile:
    dt1.to_string(dfile, columns=to_include)
with open('dist-table-part-ref.txt', 'w') as dfile:    
    dt2.to_string(dfile, columns=to_include)
```
