### PR TITLE
Rewrite pit_liability for iterator

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -183,7 +183,7 @@ class Calculator(object):
         tax_stcg_splrate(self.__policy, self.__records)
         tax_ltcg_splrate(self.__policy, self.__records)
         tax_specialrates(self.__policy, self.__records)
-        pit_liability(self)
+        pit_liability(self.__policy, self.__records)
         # TODO: ADD: expanded_income(self.__policy, self.__records)
         # TODO: ADD: aftertax_income(self.__policy, self.__records)
 


### PR DESCRIPTION
This PR rewrites the `pit_liability` function in `functions.py` to use the `iterate_jit` logic. This makes it clearer to understand the calculations in the function and will run faster on a large dataset. 

This rewrite does not change the results.