### PR TITLE
Computing CIT Liability

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -23,7 +23,7 @@ from taxcalc.functions import (net_salary_income, net_rental_income,
                                tax_specialrates, current_year_losses,
                                brought_fwd_losses, agri_income, pit_liability)
 from taxcalc.corpfunctions import (corp_GTI_before_set_off, GTI_and_losses,
-                                   net_tax_liability_a, net_tax_liability_b)
+                                   cit_liability)
 from taxcalc.policy import Policy
 from taxcalc.records import Records
 from taxcalc.corprecords import CorpRecords
@@ -154,8 +154,6 @@ class Calculator(object):
         # For now, don't zero out for corporate
         # pdb.set_trace()
         # Corporate calculations
-        net_tax_liability_a(self.__policy, self.__corprecords)
-        net_tax_liability_b(self)
         net_rental_income(self.__policy, self.__corprecords)
         income_business_profession(self.__policy, self.__corprecords)
         total_other_income(self.__policy, self.__corprecords)
@@ -169,6 +167,7 @@ class Calculator(object):
         tax_stcg_splrate(self.__policy, self.__corprecords)
         tax_ltcg_splrate(self.__policy, self.__corprecords)
         tax_specialrates(self.__policy, self.__corprecords)
+        cit_liability(self.__policy, self.__corprecords)
         # Individual calculations
         net_salary_income(self.__policy, self.__records)
         net_rental_income(self.__policy, self.__records)

--- a/taxcalc/corpfunctions.py
+++ b/taxcalc/corpfunctions.py
@@ -12,17 +12,6 @@ from taxcalc.decorators import iterate_jit
 
 
 @iterate_jit(nopython=True)
-def net_tax_liability_a(NET_TAX_LIABILTY, NET_TAX_LIABILITY_B,
-                        citax_rescale_rate):
-    """
-    Spit out tax liability (placeholder)
-    """
-    # TODO: replace this function with something else
-    NET_TAX_LIABILITY_A = NET_TAX_LIABILTY * citax_rescale_rate
-    return NET_TAX_LIABILITY_A
-
-
-@iterate_jit(nopython=True)
 def corp_GTI_before_set_off(INCOME_HP, Income_BP, ST_CG_AMT_1, ST_CG_AMT_2,
                             ST_CG_AMT_APPRATE, LT_CG_AMT_1, LT_CG_AMT_2,
                             TOTAL_INCOME_OS, GTI_Before_Loss):
@@ -58,12 +47,55 @@ def GTI_and_losses(Loss_CFLimit, GTI_Before_Loss, CY_Losses,
             newloss5, newloss6, newloss7, newloss8)
 
 
-def net_tax_liability_b(calc):
+@iterate_jit(nopython=True)
+def cit_liability(cit_rate, cit_surcharge_rate, cit_surcharge_thd, cess_rate,
+                  TTI, TI_special_rates, tax_TI_special_rates,
+                  Aggregate_Income, tax_Aggregate_Income,
+                  Total_Tax_Cap_Gains, Total_Tax_STCG, Total_Tax_LTCG, tax_TTI,
+                  surcharge, cess, citax):
     """
-    Spit out tax liability (placeholder)
+    Compute tax liability given the progressive tax rate schedule specified
+    by the (marginal tax) rate* and (upper tax bracket) brk* parameters and
+    given taxable income (taxinc)
+
+    Subtract 'TI_special_rates' from 'TTI' to get the portion of total income
+    that is taxed at normal rates. Now add agricultural income (income used for
+    rate purpose only) to get Aggregate_Income.
     """
-    # TODO: replace this function with something else
-    NET_TAX_LIABILITY = calc.carray('NET_TAX_LIABILTY')
-    citax_rescale_rate = calc.policy_param('citax_rescale_rate')
-    TAX2 = NET_TAX_LIABILITY * citax_rescale_rate
-    calc.carray('NET_TAX_LIABILITY_B', TAX2)
+    # subtract TI_special_rates from TTI to get Aggregate_Income, which is
+    # the portion of TTI that is taxed at normal rates
+    taxinc = TTI - TI_special_rates
+    taxinc = max(0., taxinc)
+    # Check this later
+    Aggregate_Income = taxinc
+    # calculate tax on taxable income subject to taxation at normal rates
+    # NOTE: Tax_ST_CG_APPRATE is not calculated here because its stacking
+    #       and scope assumptions have not been specified.  If it is ever
+    #       calculated here, be sure to add it to Total_Tax_STCG variable.
+    surcharge_rate1 = cit_surcharge_rate[0]
+    surcharge_rate2 = cit_surcharge_rate[1]
+    surcharge_rate3 = cit_surcharge_rate[2]
+    surcharge_thd1 = cit_surcharge_thd[0]
+    surcharge_thd2 = cit_surcharge_thd[1]
+    # compute tax on income taxed at normal rates
+    tax_normal_rates = cit_rate * taxinc
+    tax_Aggregate_Income = tax_normal_rates
+    # compute tax_TTI
+    tax_TTI = tax_normal_rates + tax_TI_special_rates
+    tax = tax_TTI
+    # compute surcharge amount
+    if TTI < surcharge_thd1:
+        surcharge = tax * surcharge_rate1
+    else:
+        if TTI >= surcharge_thd1 and TTI < surcharge_thd2:
+            surcharge = tax * surcharge_rate2
+        else:
+            surcharge = tax * surcharge_rate3
+    tax += surcharge
+    # compute cess amount
+    cess = tax * cess_rate
+    # compute pitax amount
+    citax = tax + cess
+    Total_Tax_Cap_Gains = Total_Tax_STCG + Total_Tax_LTCG
+    return (Aggregate_Income, tax_Aggregate_Income, tax_TTI,
+            Total_Tax_Cap_Gains, surcharge, cess, citax)

--- a/taxcalc/corprecords.py
+++ b/taxcalc/corprecords.py
@@ -301,7 +301,6 @@ class CorpRecords(object):
         GF_DEDUCTION_10AA = self.gfactors.factor_value('DEDU_SEC_10A_OR_10AA',
                                                        year)
         GF_NET_AGRC_INCOME = self.gfactors.factor_value('AGRI_INCOME', year)
-        self.NET_TAX_LIABILTY *= GF_CORP1
         self.ST_CG_AMT_1 *= GF_ST_CG_AMT_1
         self.ST_CG_AMT_2 *= GF_ST_CG_AMT_2
         self.ST_CG_AMT_APPRATE *= GF_STCG_APPRATE
@@ -351,7 +350,6 @@ class CorpRecords(object):
         BF_DEDUCTION_10AA = blowup_data.loc[0, 'DEDUCT_SEC_10A_OR_10AA']
         BF_NET_AGRC_INC = blowup_data.loc[0, 'NET_AGRC_INCOME']
         # Apply blow-up factors
-        data1['NET_TAX_LIABILTY'] = data1['NET_TAX_LIABILTY'] * BF_CORP1
         data1['INCOME_HP'] = data1['INCOME_HP'] * BF_RENT
         temp = data1['PRFT_GAIN_BP_OTHR_SPECLTV_BUS']
         data1['PRFT_GAIN_BP_OTHR_SPECLTV_BUS'] = temp * BF_BP_NONSPECULAT

--- a/taxcalc/corprecords_variables.json
+++ b/taxcalc/corprecords_variables.json
@@ -130,11 +130,6 @@
       "type": "float",
       "desc": "Loss lagged 8 year",
       "form": {"2017": "ITR-6 Sch. CFL"}
-    },
-    "NET_TAX_LIABILTY": {
-      "type": "float",
-      "desc": "CIT liability",
-      "form": {"2017": "ITR-1 line D11"}
     }
   },
   "calc": {
@@ -167,6 +162,11 @@
       "type": "float",
       "desc": "tax on Long Term Capital Gains at special rates",
       "form": {"2017": "Not real"}
+    },
+    "Total_Tax_Cap_Gains": {
+      "type": "float",
+      "desc": "Total Capital Gains Total_Tax_STCG + Total_Tax_LTCG (Total_Tax_Cap_Gains)",
+      "form": {"2017": "Not in Form"}
     },
     "TI_special_rates": {
       "type": "float",
@@ -238,6 +238,11 @@
       "desc": "Computed carried forward loss",
       "form": {"2017": "ITR-6 Sch. CFL"}
     },
+    "Aggregate_Income": {
+      "type": "float",
+      "desc": "Income taxed at normal rates TTI minus TI_special_rates",
+      "form": {"2017": "ITR-6 Part B-TI line 17"}
+    },
     "GTI": {
       "type": "float",
       "desc": "Gross Total Income (GTI)",
@@ -258,20 +263,35 @@
       "desc": "Taxable Total Income (TTI)",
       "form": {"2017": "ITR-6 Part B-TI line 13"}
     },
+    "tax_Aggregate_Income": {
+      "type": "float",
+      "desc": "Tax liability on Income taxed at normal rates",
+      "form": {"2017": "ITR-6 Part B TTI-2a"}
+    },
     "TI_special_rates": {
       "type": "float",
       "desc": "Taxable Total Income (TTI) taxed at special rates",
       "form": {"2017": "ITR-6 Part B-TI line 14"}
     },
-    "NET_TAX_LIABILITY_A": {
+    "tax_TTI": {
       "type": "float",
-      "desc": "half CIT liability",
-      "form": {"2017": "Not real"}
+      "desc": "Tax liability on TI which is tax_Aggregate_Income plus tax_TI_special_rates less agricultural rebate",
+      "form": {"2017": "ITR-6 Part B TTI-2a"}
     },
-    "NET_TAX_LIABILITY_B": {
+    "surcharge": {
       "type": "float",
-      "desc": "half CIT liability",
-      "form": {"2017": "Not real"}
+      "desc": "Surcharge on income above surcharge_thd",
+      "form": {"2017": "ITR-6 Part B TTI-2diii"}
+    },
+    "cess": {
+      "type": "float",
+      "desc": "cess on tax and surcharge",
+      "form": {"2017": "ITR-6 Part B TTI-2e"}
+    },
+    "citax": {
+      "type": "float",
+      "desc": "PIT liability",
+      "form": {"2017": "ITR-6 Part B TTI-2f"}
     }
   }
 }

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -358,6 +358,48 @@
         "out_of_range_action": "stop"
     },
 
+    "_cit_surcharge_rate": {
+        "long_name": "rate at which surcharge is levied for companies",
+        "description": "surcharge rates for companies",
+        "itr_ref": "Tax Computation Table, Finance Act",
+        "notes": "",
+        "row_var": "AYEAR",
+        "row_label": ["2017"],
+        "start_year": 2017,
+        "cpi_inflatable": false,
+        "cpi_inflated": false,
+        "col_var": "TTI1",
+        "col_label": ["bracket1", "bracket2", "bracket3"],
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [[0.0, 0.07, 0.12]],
+        "range": {"min": 0, "max": 1},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
+    "_cit_surcharge_thd": {
+        "long_name": "income threshold for levy of surcharge for companies",
+        "description": "income threshold for surcharge for companies",
+        "itr_ref": "Tax Computation Table, Finance Act",
+        "notes": "",
+        "row_var": "AYEAR",
+        "row_label": ["2017"],
+        "start_year": 2017,
+        "cpi_inflatable": true,
+        "cpi_inflated": false,
+        "col_var": "TTI2",
+        "col_label": ["bracket1", "bracket2"],
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [[10000000, 100000000]],
+        "range": {"min": 0, "max": 9e99},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
     "_cess_rate": {
         "long_name": "rate at which cess is levied",
         "description": "cess applied to sum of tax and surcharge",
@@ -379,13 +421,13 @@
         "out_of_range_action": "stop"
     },
 
-    "_citax_rescale_rate": {
-        "long_name": "rate at which corporate tax is recaled",
-        "description": "placeholder for corporate policy parameters",
-        "itr_ref": "ITR-6, Some Section",
+    "_cit_rate": {
+        "long_name": "rate at which corporates are taxed",
+        "description": "Corporate Tax rate",
+        "itr_ref": "Schedule 1 Finance Act",
         "notes": "",
         "row_var": "AYEAR",
-        "row_label": ["2017", "2018"],
+        "row_label": ["2017"],
         "start_year": 2017,
         "cpi_inflatable": false,
         "cpi_inflated": false,
@@ -393,8 +435,8 @@
         "col_label": "",
         "boolean_value": false,
         "integer_value": false,
-        "value": [1.0, 1.0],
-        "range": {"min": 0, "max": 9e99},
+        "value": [0.3],
+        "range": {"min": 0, "max": 1},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop"

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -183,7 +183,8 @@ def pit_liability(rate1, rate2, rate3, rate4, tbrk1, tbrk2, tbrk3, tbrk4,
                   rebate_rate, rebate_thd, rebate_ceiling,
                   surcharge_rate, surcharge_thd, cess_rate,
                   TTI, TI_special_rates, tax_TI_special_rates,
-                  Income_Rate_Purpose, AGEGRP, Total_Tax_STCG, Total_Tax_LTCG,
+                  Income_Rate_Purpose, AGEGRP, Total_Tax_Cap_Gains,
+                  Total_Tax_STCG, Total_Tax_LTCG,
                   Aggregate_Income, tax_Aggregate_Income, rebate_agri,
                   tax_TTI, rebate, surcharge, cess, pitax):
     """
@@ -246,19 +247,18 @@ def pit_liability(rate1, rate2, rate3, rate4, tbrk1, tbrk2, tbrk3, tbrk4,
     rebate = min(tax_TTI, rebate)
     tax = tax_TTI - rebate
     # compute surcharge amount
-    if taxinc < surcharge_thd1:
-        surcharge = taxinc * surcharge_rate1
+    if TTI < surcharge_thd1:
+        surcharge = tax * surcharge_rate1
     else:
-        if taxinc >= surcharge_thd1 and taxinc < surcharge_thd2:
-            taxinc * surcharge_rate2
+        if TTI >= surcharge_thd1 and TTI < surcharge_thd2:
+            surcharge = tax * surcharge_rate2
         else:
-            taxinc * surcharge_rate3
+            surcharge = tax * surcharge_rate3
     tax += surcharge
     # compute cess amount
     cess = tax * cess_rate
     # compute pitax amount
     pitax = tax + cess
-    # calculate Total_Tax_Cap_Gains
     Total_Tax_Cap_Gains = Total_Tax_STCG + Total_Tax_LTCG
     return (Aggregate_Income, tax_Aggregate_Income, rebate_agri, tax_TTI,
-            rebate, surcharge, cess, pitax, Total_Tax_Cap_Gains)
+            Total_Tax_Cap_Gains, rebate, surcharge, cess, pitax)


### PR DESCRIPTION
Incorporated the Tax liability computation for corporate data. It does not include MAT & Relief calculation currently. These will be done later.