### PR TITLE
Extend model to 2021

### DIFF
--- a/taxcalc/corprecords.py
+++ b/taxcalc/corprecords.py
@@ -360,28 +360,29 @@ class CorpRecords(object):
         """
         # read in the blow-up factors
         blowup_path = os.path.join(CorpRecords.CUR_PATH, self.blowfactors_path)
-        blowup_data = pd.read_csv(blowup_path)
+        blowup_data_all = pd.read_csv(blowup_path, index_col='YEAR')
+        blowup_data = blowup_data_all.loc[self.panelyear + 4]
         # extract the observations for the intended year
         assessyear = np.array(self.full_panel['ASSESSMENT_YEAR'])
         data1 = self.full_panel[assessyear == self.panelyear].reset_index()
         # apply the blowup factors
-        BF_CORP1 = blowup_data.loc[0, 'AGGREGATE_LIABILTY']
-        BF_RENT = blowup_data.loc[0, 'INCOME_HP']
-        BF_BP_NONSPECULAT = blowup_data.loc[0, 'PRFT_GAIN_BP_OTHR_SPECLTV_BUS']
-        BF_BP_SPECULATIVE = blowup_data.loc[0, 'PRFT_GAIN_BP_SPECLTV_BUS']
-        BF_BP_SPECIFIED = blowup_data.loc[0, 'PRFT_GAIN_BP_SPCFD_BUS']
-        BF_BP_PATENT115BBF = blowup_data.loc[0, 'AGGREGATE_LIABILTY']
-        BF_ST_CG_AMT_1 = blowup_data.loc[0, 'ST_CG_AMT_1']
-        BF_ST_CG_AMT_2 = blowup_data.loc[0, 'ST_CG_AMT_2']
-        BF_LT_CG_AMT_1 = blowup_data.loc[0, 'LT_CG_AMT_1']
-        BF_LT_CG_AMT_2 = blowup_data.loc[0, 'LT_CG_AMT_2']
-        BF_STCG_APPRATE = blowup_data.loc[0, 'ST_CG_AMT_APPRATE']
-        BF_OINCOME = blowup_data.loc[0, 'TOTAL_INCOME_OS']
-        BF_CYL_SET_OFF = blowup_data.loc[0, 'CYL_SET_OFF']
-        BF_DEDUCTIONS = blowup_data.loc[0, 'TOTAL_DEDUC_VIA']
-        BF_DEDUCTION_10AA = blowup_data.loc[0, 'DEDUCT_SEC_10A_OR_10AA']
-        BF_NET_AGRC_INC = blowup_data.loc[0, 'NET_AGRC_INCOME']
-        BF_INVESTMENT = blowup_data.loc[0, 'INVESTMENT']
+        BF_CORP1 = blowup_data['AGGREGATE_LIABILTY']
+        BF_RENT = blowup_data['INCOME_HP']
+        BF_BP_NONSPECULAT = blowup_data['PRFT_GAIN_BP_OTHR_SPECLTV_BUS']
+        BF_BP_SPECULATIVE = blowup_data['PRFT_GAIN_BP_SPECLTV_BUS']
+        BF_BP_SPECIFIED = blowup_data['PRFT_GAIN_BP_SPCFD_BUS']
+        BF_BP_PATENT115BBF = blowup_data['AGGREGATE_LIABILTY']
+        BF_ST_CG_AMT_1 = blowup_data['ST_CG_AMT_1']
+        BF_ST_CG_AMT_2 = blowup_data['ST_CG_AMT_2']
+        BF_LT_CG_AMT_1 = blowup_data['LT_CG_AMT_1']
+        BF_LT_CG_AMT_2 = blowup_data['LT_CG_AMT_2']
+        BF_STCG_APPRATE = blowup_data['ST_CG_AMT_APPRATE']
+        BF_OINCOME = blowup_data['TOTAL_INCOME_OS']
+        BF_CYL_SET_OFF = blowup_data['CYL_SET_OFF']
+        BF_DEDUCTIONS = blowup_data['TOTAL_DEDUC_VIA']
+        BF_DEDUCTION_10AA = blowup_data['DEDUCT_SEC_10A_OR_10AA']
+        BF_NET_AGRC_INC = blowup_data['NET_AGRC_INCOME']
+        BF_INVESTMENT = blowup_data['INVESTMENT']
         # Apply blow-up factors
         data1['INCOME_HP'] = data1['INCOME_HP'] * BF_RENT
         temp = data1['PRFT_GAIN_BP_OTHR_SPECLTV_BUS']

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -44,7 +44,7 @@ class Policy(ParametersBase):
     DEFAULTS_FILENAME = 'current_law_policy.json'
     JSON_START_YEAR = 2017  # remains the same unless earlier data added
     LAST_KNOWN_YEAR = 2017  # last year for which indexed param vals are known
-    LAST_BUDGET_YEAR = 2019  # increases by one for every new assessment year
+    LAST_BUDGET_YEAR = 2021  # increases by one for every new assessment year
     DEFAULT_NUM_YEARS = LAST_BUDGET_YEAR - JSON_START_YEAR + 1
 
     def __init__(self,


### PR DESCRIPTION
This PR extends `pitaxcalc-demo` to run through 2021, instead of just through 2019. This allows us to use the full five years of the corporate panel. 

This also cleans up the logic of handling the blowup factors slightly. 

@sebastiansajie 